### PR TITLE
Show FreeSWITCH failed registration counts

### DIFF
--- a/FreeSWITCH/show_failed_registrations.sh
+++ b/FreeSWITCH/show_failed_registrations.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+# usage: ./show_failed_registrations.sh /var/log/freeswitch/error.log
+# can also use it on the rotated logs, eg error.log.1, error.log.2.gz, etc
+
+zgrep "sofia_reg.c:2394 Can't find user" $1 | awk -F " " '{ printf "%s\n", $8}' | sort | uniq -c | sort -n


### PR DESCRIPTION
This simple shell script will parse the FreeSWITCH error.log file and output a listing of which user@realm failed registration attempts, as well as the count of how many times that user@realm failed.
