### PR TITLE
Changed port for Source in clone_tools.hrl in the clone_tools folder for...

### DIFF
--- a/clone_tools/src/clone_tools.hrl
+++ b/clone_tools/src/clone_tools.hrl
@@ -5,7 +5,7 @@
 
 %% SOURCE should be set to a single node
 %% in the old database cluster.
--define(SOURCE, "http://127.0.0.1:15984/").
+-define(SOURCE, "http://127.0.0.1:5984/").
 
 %% MAX_CR_AGE is the maxium age (in days)
 %% of the CDRs to copy (IE: last 30 days).


### PR DESCRIPTION
... consistency.

I thought it was a bit confusing to have port 15984 when the config file clearly states: "SOURCE should be set to a single node in the old database cluster", so I changed it to Bigcouch default data port: 5984.
