### PR TITLE
Interface bouncy bouncy

### DIFF
--- a/simple-installer/install_kazoo
+++ b/simple-installer/install_kazoo
@@ -320,9 +320,7 @@ set_interfaces_up(){
              interfaces+=(${int%%:*})
         fi
     done < <(ip link)
-
-    dbg "Restarting networking with:${NC} service network restart"
-
+    
     for int in ${interfaces[@]}; do
         local $answer=""
         confirm "Interface $int is currently down, do you want to bring this up? [Y|N]"


### PR DESCRIPTION
Added support for really basic IF management since you can now configure new interfaces via the install main menu. Now IFs get set to Up and enabled on boot. Both these actiosn are user configurable via confirm calls. 
