### PR TITLE
Kazoo3.19 media prompts

### DIFF
--- a/simple-installer/install_kazoo
+++ b/simple-installer/install_kazoo
@@ -55,11 +55,9 @@ packages['kazoo-ui']=$kazoo_ui_package
 packages['haproxy']=$haproxy_package
 packages['rabbitmq']=$rabbitmq_package
 
-
 #filenames
 install_log="/var/log/kazoo_install.log"
 lockfile="/root/kazoo_install.lockfile"
-
 
 #color and Debug printing funcs
 green='\e[0;32m'
@@ -361,7 +359,6 @@ set_interfaces_up(){
 
 }
 
-
 set_network(){
     local answer  
     confirm "Do you want to setup your network configuration? [y|n]"
@@ -372,7 +369,6 @@ set_network(){
          service network restart
     fi 
 }
-
 
 set_hostname(){
     #warn user and get permission to delete database information
@@ -682,7 +678,6 @@ handle_args $@
 check_lock
 banner
 set_hostname
-
 
 ! [[ ${all_in_one:-} ]] && set_network
 

--- a/simple-installer/setup_packages
+++ b/simple-installer/setup_packages
@@ -147,9 +147,15 @@ update_bigcouch_views_dbg="Updating all Bigcouch views with: ${NC}sup whapps_mai
 update_bigcouch_views_cmd="/opt/kazoo/utils/sup/sup whapps_maintenance migrate"
 update_bigcouch_views_error="whapps blocking_refresh failed! rerun with: ${NC}sup whapps_maintenance migrate"
 
-import_media_files_dbg="Importing media files with: ${NC}sup whistle_media_maintenance import_prompts /opt/kazoo/system_media/ en-us "
-import_media_files_cmd="sup whistle_media_maintenance import_prompts /opt/kazoo/system_media/ en-us"
-import_media_files_error="Media prompt import failed with: ${NC}sup whistle_media_maintenance import_prompts /opt/kazoo/system_media/ en-us"
+if [ -d /opt/kazoo/system_media/en-us ]; then  
+    media_dir="/opt/kazoo/system_media/en-us"
+else 
+    media_dir="/opt/kazoo/system_media"
+fi
+
+import_media_files_dbg="Importing media files with: ${NC}sup whistle_media_maintenance import_prompts ${media_dir} en-us "
+import_media_files_cmd="sup whistle_media_maintenance import_prompts ${media_dir} en-us"
+import_media_files_error="Media prompt import failed with: ${NC}sup whistle_media_maintenance import_prompts ${media_dir} en-us"
 
 create_account_dbg="Creating admin account with: ${NC}sup crossbar_maintenance create_account TOKEN"
 create_account_cmd="/opt/kazoo/utils/sup/sup crossbar_maintenance create_account TOKEN"


### PR DESCRIPTION
Had to add support for checking if subdirectory en-us exists in /opt/kazoo/system_media as kazoo v3.19 has updated the directory by moving the prompts from system media into /opt/kazoo/system_media/en-us. 

Build has been tested and confirmed to successfully import v3.19 media. 

Also cleaned up some unneeded whitespace in install_kazoo 